### PR TITLE
package malkusch/php-mock moved to php-mock/php-mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "instaclick/coding-standard":            "~1.1",
         "squizlabs/php_codesniffer":             "~1.5",
         "satooshi/php-coveralls":                "~0.6",
-        "malkusch/php-mock":                     "~0.4",
+        "php-mock/php-mock":                     "^0.4",
         "instaclick/object-calisthenics-sniffs": "dev-master",
         "instaclick/symfony2-coding-standard":   "dev-remaster"
     },


### PR DESCRIPTION
Hi,
I moved malkusch/php-mock to [php-mock/php-mock](https://github.com/php-mock/php-mock).
