### PR TITLE
Patch to return all sets as part of a search query

### DIFF
--- a/src/Riak/Client/Core/Transport/Proto/Search/ProtoSearch.php
+++ b/src/Riak/Client/Core/Transport/Proto/Search/ProtoSearch.php
@@ -79,7 +79,11 @@ class ProtoSearch extends ProtoStrategy
         }
 
         foreach ($doc->fields as $pair) {
-            $values[$pair->key] = $pair->value;
+            if(substr($pair->key, -4) === '_set') {
+                $values[$pair->key][] = $pair->value;
+            } else {
+                $values[$pair->key] = $pair->value;
+            }
         }
 
         return $values;


### PR DESCRIPTION
I've noticed a small issue with search results when using the protocol buffer client wherein "set" results only contain the last set value. I traced this to the docToArray function which is changing the response from riak/ solr.

This is the code we're using to run the search query

``` php
<?php
        $rowsPerPage = 10;
        $page        = 1;
        $start       = $rowsPerPage * ($page - 1);

        $search = Search::builder()
            ->withNumRows($rowsPerPage)
            ->withIndex("articles")
            ->withStart($start)
            ->withQuery('*:*')
            ->build();

        $searchResult = $this->datastore->execute($search);
        $results      = $searchResult->getResults();
```

Current $results output

```
"data": [
   {
      "author_set": "b463acb0-c4d1-443f-b092-88f6bad5da43",
      "category_set": "e7091489-0e20-490e-957b-2cea2f0dea9f",
      "name_register": "Article name",
      "strapline_register": "Article strapline",
      "synopsis_register": "Article synopsis here",
   }
]
```

Patched $results output

```
"data": [
   {
      "author_set": [
          "a2debde5-c6fa-4912-8556-77bef0926e7d",
          "b463acb0-c4d1-443f-b092-88f6bad5da43"
       ],
       "category_set": [
          "bfaadc21-27c2-47e2-9fca-a6c1d356c14e",
          "e7091489-0e20-490e-957b-2cea2f0dea9f"
       ],
       "name_register": "Article name",
       "strapline_register": "Article strapline",
       "synopsis_register": "Article sysnopsis here",
   }
]
```
